### PR TITLE
Make swift client write buffer to file prior to break

### DIFF
--- a/src/tes/worker/swift_client.go
+++ b/src/tes/worker/swift_client.go
@@ -64,6 +64,8 @@ func (swiftAccess *SwiftAccess) Get(storage string, hostPath string, class strin
 		for {
 			len, err := res.Body.Read(buffer)
 			if err == io.EOF {
+				totalLen += len
+				file.Write(buffer[:len])
 				break
 			} else if err != nil {
 				return fmt.Errorf("Error reading file")


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR makes the swift client write the buffer contents to the local file before breaking. Previously, the for loop was reaching EOF (end of file) and breaking immediately. The for loop should instead break *after* writing the buffer.

---
<!-- Thank you for contributing to TES! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `make` does not report any errors
- [X] These changes fix #14  (github issue number if applicable).

<!-- Either: -->
- [ ] There are documentation for these changes OR
- [X] These changes do not require documentation because _it is a bug fix_

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because _Still just testing locally._

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->