### PR TITLE
Fix pathMatch() function

### DIFF
--- a/src/tes/worker/util.go
+++ b/src/tes/worker/util.go
@@ -8,12 +8,15 @@ import (
 )
 
 func pathMatch(base string, query string) (string, string) {
-	if path.Clean(base) == path.Clean(query) {
-		return query, ""
+	var normalizedBase = path.Clean(base)
+	var normalizedQuery = path.Clean(query)
+
+	if normalizedBase == normalizedQuery {
+		return normalizedQuery, ""
 	}
-	dir, file := path.Split(query)
+	dir, file := path.Split(normalizedQuery)
 	if len(dir) > 1 {
-		d, p := pathMatch(base, dir)
+		d, p := pathMatch(normalizedBase, dir)
 		return d, path.Join(p, file)
 	}
 	return "", ""


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

There is an error in **util.go** with path splitting. For example, if we submit **/mnt** for **base** and **/mnt/working_dir/output.txt** for **query** we will get stack overflow exception because of the trailing **/** after first split. So, query path should end in a slash only if it is the root **/**.

I just cleaned it up with path.Clean().

---
<!-- Thank you for contributing to TES! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `make` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are documentation for these changes OR
- [ ] These changes do not require documentation because _____

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

