### PR TITLE
Use waitgroup to properly wait for workers to cleanup.

### DIFF
--- a/src/tes/worker/slot/pool.go
+++ b/src/tes/worker/slot/pool.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	uuid "github.com/nu7hatch/gouuid"
 	"log"
+	"sync"
 	"time"
 )
 
@@ -36,28 +37,37 @@ func NewPool(slots []*Slot, idleTimeout IdleTimeout) *Pool {
 // Start the slots and track their status.
 // If the pool is idle for longer than Pool.idleTimeout, exit.
 func (pool *Pool) Start() {
-	ctx := context.Background()
-	defer ctx.Done()
+	ctx, cancel := context.WithCancel(context.Background())
+	// WaitGroup helps wait for the slots to finish and clean up.
+	var wg sync.WaitGroup
+
 	defer log.Printf("Shutting down pool")
 
+	// Ticker helps poll slot state
 	ticker := time.NewTicker(pool.statusCheckDuration)
 	defer ticker.Stop()
 
 	log.Printf("Starting pool of %d slots", len(pool.slots))
 
 	// Create and start slots.
+	// Do some bookkeeping with the WaitGroup and call slot.Run()
+	wg.Add(len(pool.slots))
 	for _, slot := range pool.slots {
-		go slot.Run(ctx)
+		go func(slot *Slot) {
+			defer wg.Done()
+			slot.Run(ctx)
+		}(slot)
 	}
 
 	// This tracks the status of concurrent job slots.
 	// If no jobs are found for awhile, the pool will shut down.
+loop:
 	for {
 		select {
 		case <-pool.idleTimeout.Done():
 			// Break the loop for shutdown
 			log.Printf("Pool has reached idle timeout")
-			return
+			break loop
 		case <-ticker.C:
 			// Check if the pool is completely idle.
 			isRunning := false
@@ -75,6 +85,11 @@ func (pool *Pool) Start() {
 			// TODO what if there are active slots, but they aren't sending status updates?
 		}
 	}
+
+	// Cancel the context, which signals the slots to finish and clean up.
+	cancel()
+	// Wait for the slots to finish.
+	wg.Wait()
 }
 
 // Generate an ID for the a Pool.


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The worker pool isn't properly waiting for the slots to shut down. This is part of the upcoming autoscaler stuff, where a pool will need to tell the scheduler that it's shutting down. I'm trying to break that work into a few smaller pull requests.

---
<!-- Thank you for contributing to TES! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `make` does not report any errors
- [ ] `make tidy` does not report any errors (except for package name related errors)
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are documentation for these changes OR
- [ ] These changes do not require documentation because _____

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
