### PR TITLE
Worker config file

### DIFF
--- a/src/tes-server/server.go
+++ b/src/tes-server/server.go
@@ -27,14 +27,8 @@ func main() {
 	contentDir := filepath.Join(dir, "..", "..", "share")
 
 	config := ga4gh_task_ref.ServerConfig{}
-	if *configFile != "" {
-		var err error
-		config, err = tes.ParseConfigFile(*configFile)
-		if err != nil {
-			log.Println("Failure Reading Config")
-			return
-		}
-	}
+	tes.LoadConfigOrExit(*configFile, &config)
+
 	if *storageDirArg != "" {
 		//server meta-data
 		storageDir, _ := filepath.Abs(*storageDirArg)

--- a/src/tes-worker/worker.go
+++ b/src/tes-worker/worker.go
@@ -28,7 +28,7 @@ func main() {
 
 	flag.Parse()
 
-	tes.LoadConfigOrExit(configFileArg, &config)
+	tes.LoadConfigOrExit(configArg, &config)
 
 	for _, i := range allowedDirsArg {
 		p, _ := filepath.Abs(i)

--- a/src/tes-worker/worker.go
+++ b/src/tes-worker/worker.go
@@ -2,33 +2,39 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+	"tes"
 	"tes/storage"
 	worker "tes/worker"
 	"tes/worker/slot"
 )
 
 func main() {
-	masterArg := flag.String("master", "localhost:9090", "Master Server")
-	workDirArg := flag.String("workdir", "volumes", "Working Directory")
-	timeoutArg := flag.Int("timeout", -1, "Timeout in seconds")
-	allowedDirsArg := flag.String("allowed", "", "Allowed directories for local FS backend")
-	nworker := flag.Int("nworkers", 4, "Worker Count")
-	logFileArg := flag.String("logfile", "", "File path to write logs to")
+	config := worker.NewConfig()
+
+	var allowedDirsArg csvArg
+	var configArg string
+	flag.StringVar(&configArg, "config", "", "Config File")
+	flag.StringVar(&config.MasterAddr, "masteraddr", config.MasterAddr, "Master Server")
+	flag.StringVar(&config.WorkDir, "workdir", config.WorkDir, "Working Directory")
+	flag.IntVar(&config.Timeout, "timeout", config.Timeout, "Timeout in seconds")
+	flag.Var(&allowedDirsArg, "alloweddirs", "Allowed directories for local FS backend")
+	flag.IntVar(&config.NumWorkers, "numworkers", config.NumWorkers, "Worker Count")
+	flag.StringVar(&config.LogPath, "logpath", config.LogPath, "File path to write logs to")
 
 	flag.Parse()
 
-	config := worker.Config{
-		MasterAddr:  *masterArg,
-		WorkDir:     *workDirArg,
-		Timeout:     *timeoutArg,
-		NumWorkers:  *nworker,
-		AllowedDirs: parseAllowedDirs(*allowedDirsArg),
-		LogPath:     *logFileArg,
+	tes.LoadConfigOrExit(configFileArg, &config)
+
+	for _, i := range allowedDirsArg {
+		p, _ := filepath.Abs(i)
+		config.AllowedDirs = append(config.AllowedDirs, p)
 	}
+
 	start(config)
 }
 
@@ -78,11 +84,17 @@ func start(config worker.Config) {
 	p.Start()
 }
 
-func parseAllowedDirs(in string) []string {
-	o := []string{}
-	for _, i := range strings.Split(in, ",") {
-		p, _ := filepath.Abs(i)
-		o = append(o, p)
+// csvArg is a helper for allowing comma-separated CLI flags.
+// See example 3 here: https://golang.org/src/flag/example_test.go
+type csvArg []string
+
+func (a *csvArg) String() string {
+	return fmt.Sprint(*a)
+}
+
+func (a *csvArg) Set(str string) error {
+	for _, i := range strings.Split(str, ",") {
+		*a = append(*a, i)
 	}
-	return o
+	return nil
 }

--- a/src/tes/config.go
+++ b/src/tes/config.go
@@ -3,17 +3,39 @@ package tes
 import (
 	"github.com/ghodss/yaml"
 	"io/ioutil"
-	"tes/server/proto"
+	"log"
+	"os"
+	"path/filepath"
 )
 
 // ParseConfigFile parses a TES config file, which is formatted in YAML,
 // and returns a ServerConfig struct.
-func ParseConfigFile(path string) (ga4gh_task_ref.ServerConfig, error) {
-	doc := ga4gh_task_ref.ServerConfig{}
+func ParseConfigFile(path string, doc interface{}) error {
 	source, err := ioutil.ReadFile(path)
 	if err != nil {
-		return doc, err
+		return err
 	}
 	err = yaml.Unmarshal(source, &doc)
-	return doc, nil
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func LoadConfigOrExit(relpath string, config interface{}) {
+	var err error
+	if relpath != "" {
+		var abspath string
+		abspath, err = filepath.Abs(relpath)
+		if err != nil {
+			log.Printf("Failure reading config: %s", abspath)
+			os.Exit(1)
+		}
+		log.Printf("Using config file: %s", abspath)
+		err = ParseConfigFile(abspath, &config)
+		if err != nil {
+			log.Printf("Failure reading config: %s", abspath)
+			os.Exit(1)
+		}
+	}
 }

--- a/src/tes/worker/config.go
+++ b/src/tes/worker/config.go
@@ -9,3 +9,13 @@ type Config struct {
 	AllowedDirs []string
 	LogPath     string
 }
+
+// NewConfig returns a new worker config instance with default values.
+func NewConfig() Config {
+	return Config{
+		MasterAddr: "localhost:9090",
+		WorkDir:    "volumes",
+		Timeout:    -1,
+		NumWorkers: 4,
+	}
+}

--- a/tests/sample-worker-config.yaml
+++ b/tests/sample-worker-config.yaml
@@ -1,0 +1,1 @@
+NumWorkers: 2


### PR DESCRIPTION
This allows the worker to read config from a file, which will be needed for the upcoming OpenStack autoscaler demo.