### PR TITLE
gitattributes file for suppressing .pb.go in git diff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pb.go -diff


### PR DESCRIPTION
Just wondering if you guys want this, I find it useful.

I find the .pb.go files in `git diff` get in the way, so I figured out how to suppress them using .gitattributes